### PR TITLE
Optimize code and speedup execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ notebooks
 __pycache__
 versions
 samples
+venv

--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,14 @@
+from yolosplitter import YoloSplitter
+import logging
+
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+dataset_path = 'xxxFolder'
+
+ys = YoloSplitter(imgFormat=['.jpg', '.jpeg'], labelFormat=['.txt'] )
+
+# If you have yolo-format dataset already on the system
+df = ys.from_yolo_dir(input_dir=dataset_path,ratio=(0.8,0.2,0.0),return_df=True)
+
+ys.save_split(dataset_path + '_splitted')

--- a/src/yolosplitter.py
+++ b/src/yolosplitter.py
@@ -58,14 +58,14 @@ class YoloSplitter:
         input_df["set"] = ""
 
         if self.__error_files:
-            print(f"Total Error Files: {len(self.__error_files)} ")
+            logging.warn(f"Total Error Files: {len(self.__error_files)} ")
 
         # Splitted df (train/test/val)
         splitted_df = self.__make_split(input_df, ratio=ratio)
 
         self.__DATAFRAME = splitted_df
 
-        print(self.info())
+        logging.info(self.info())
 
         if return_df:
             return self.__DATAFRAME[self.__req_cols]
@@ -99,7 +99,7 @@ class YoloSplitter:
             all_dataframes.append(temp_df)
 
         if self.__error_files:
-            print(f"Total Error Files: {len(self.__error_files)} ")
+            logging.warn(f"Total Error Files: {len(self.__error_files)} ")
 
         input_df = pd.concat(all_dataframes, ignore_index=True, sort=False)
 
@@ -159,7 +159,7 @@ class YoloSplitter:
                 dataset["annots"].append(annot_data)
                 dataset["cls_names"].append(cls_names)
         endReadAnnotation = time()
-        logging.debug(f"Time execution read dataset {endReadAnnotation-startReadAnnotation}s for {len(dataset)} elements")
+        logging.debug(f"Time execution read dataset {endReadAnnotation-startReadAnnotation}s for {len(dataset["images_path"])} elements")
 
         return dataset
 
@@ -200,7 +200,7 @@ class YoloSplitter:
         splitted_df = pd.concat(
             [train_df, val_df, test_df], ignore_index=True, sort=False
         )
-        print(
+        logging.info(
             f"\nTrain size:{train_length},Validation size:{val_length},Test size :{test_length}\n"
         )
 
@@ -236,7 +236,7 @@ class YoloSplitter:
 
         input_df = self.__DATAFRAME
 
-        print(f"Saving New split in '{output_dir}' dir")
+        logging.info(f"Saving New split in '{output_dir}' dir")
 
         if input_df is None:
             raise ValueError(

--- a/src/yolosplitter.py
+++ b/src/yolosplitter.py
@@ -150,10 +150,10 @@ class YoloSplitter:
                 annot_data, cls_names = temparray
                 if os.path.splitext(All_Labels[i])[0] not in tmp_images_to_check:
                     continue
-                dataset["images_path"].append(os.path.join(image_dir, All_Images[i]))
+                dataset["images_path"].append(os.path.join(image_dir, os.path.splitext(All_Labels[i])[0] + '.jpg'))
                 dataset["labels_path"].append(os.path.join(label_dir, All_Labels[i]))
-                dataset["images"].append(os.path.join(All_Images[i]))
-                dataset["labels"].append(os.path.join(All_Images[i]))
+                dataset["images"].append(os.path.join(os.path.splitext(All_Labels[i])[0] + '.jpg'))
+                dataset["labels"].append(os.path.join(All_Labels[i]))
                 dataset["annots"].append(annot_data)
                 dataset["cls_names"].append(cls_names)
         endReadAnnotation = time()

--- a/src/yolosplitter.py
+++ b/src/yolosplitter.py
@@ -78,7 +78,6 @@ class YoloSplitter:
         """
         self.__DATAFRAME = None
         self.__error_files = []
-        self.__input_dir = input_dir
 
         set_dir_names = [
             i for i in os.listdir(input_dir) if i in ["train", "test", "valid"]

--- a/src/yolosplitter.py
+++ b/src/yolosplitter.py
@@ -166,9 +166,10 @@ class YoloSplitter:
         if round(sum(ratio), 5) != 1:
             raise ValueError("Ratio sum should be equal to 1")
 
-        if len(ratio) == 2 or len(ratio) == 3:
+        if len(ratio) == 2:
             train_ratio, val_ratio = ratio
-
+        elif len(ratio) == 3:
+            train_ratio, val_ratio, _ = ratio
         else:
             raise ValueError("Ratio must be tuple length of 2 or 3")
 

--- a/src/yolosplitter.py
+++ b/src/yolosplitter.py
@@ -81,9 +81,7 @@ class YoloSplitter:
         set_dir_names = [
             i for i in os.listdir(input_dir) if i in ["train", "test", "valid", "val"]
         ]
-
-        # TODO structure with images and labels as folder and train, test and valid as subfolder
-
+        
         all_dataframes = []
 
         for folder_name in set_dir_names:            
@@ -161,7 +159,6 @@ class YoloSplitter:
         logging.debug(f"Time execution read dataset {endReadAnnotation-startReadAnnotation}s for {len(dataset["images_path"])} elements")
 
         return dataset
-
 
     def __make_split(self, input_df, ratio):
         if round(sum(ratio), 5) != 1:

--- a/src/yolosplitter.py
+++ b/src/yolosplitter.py
@@ -80,11 +80,10 @@ class YoloSplitter:
         self.__error_files = []
 
         set_dir_names = [
-            i for i in os.listdir(input_dir) if i in ["train", "test", "valid"]
+            i for i in os.listdir(input_dir) if i in ["train", "test", "valid", "val"]
         ]
 
         # TODO structure with images and labels as folder and train, test and valid as subfolder
-        # TODO structure with val as subfolder
 
         all_dataframes = []
 
@@ -167,15 +166,11 @@ class YoloSplitter:
         if round(sum(ratio), 5) != 1:
             raise ValueError("Ratio sum should be equal to 1")
 
-        if len(ratio) == 2:
+        if len(ratio) == 2 or len(ratio) == 3:
             train_ratio, val_ratio = ratio
-            test_ratio = 0
-
-        elif len(ratio) == 3:
-            train_ratio, val_ratio, test_ratio = ratio
 
         else:
-            raise ValueError("ratio must be tuple length of 2 or 3")
+            raise ValueError("Ratio must be tuple length of 2 or 3")
 
         total_length = len(input_df)
         train_length = round(train_ratio * len(input_df))

--- a/src/yolosplitter.py
+++ b/src/yolosplitter.py
@@ -183,7 +183,7 @@ class YoloSplitter:
 
         # Shuffle new_set column to new set
         set_names = (
-            ["train"] * train_length + ["valid"] * val_length + ["test"] * test_length
+            ["train"] * train_length + ["val"] * val_length + ["test"] * test_length
         )
         random.shuffle(set_names)
 
@@ -194,9 +194,7 @@ class YoloSplitter:
         splitted_df = pd.concat(
             [train_df, val_df, test_df], ignore_index=True, sort=False
         )
-        logging.info(
-            f"\nTrain size:{train_length},Validation size:{val_length},Test size :{test_length}\n"
-        )
+        logging.info(f"Train size:{train_length},Validation size:{val_length},Test size :{test_length}")
 
         _cls_names = set(
             [name for name_list in splitted_df["cls_names"] for name in name_list]
@@ -216,7 +214,8 @@ class YoloSplitter:
         return self.__error_files
 
     def get_dataframe(self):
-        return self.__DATAFRAME[self.__req_cols]
+        if self.__DATAFRAME is not None:
+            return self.__DATAFRAME[self.__req_cols]
 
     def info(self):
         return self.__info
@@ -232,7 +231,7 @@ class YoloSplitter:
 
         logging.info(f"Saving New split in '{output_dir}' dir")
 
-        if input_df is None:
+        if input_df is None or self.__DATAFRAME is None:
             raise ValueError(
                 "Dataframe is not created. Plase ran from_yolo_dir or from_mixed_dir first"
             )
@@ -271,14 +270,14 @@ class YoloSplitter:
             self.__DATAFRAME.new_set.value_counts().to_dict()[i]
             if i in self.__DATAFRAME.new_set.value_counts().to_dict()
             else 0
-            for i in ["train", "valid", "test"]
+            for i in ["train", "val", "test"]
         ]
 
         yamlFile["nc"] = len(cls_names)
         yamlFile["names"] = cls_names
         yamlFile["train"] = os.path.join(output_dir, "train")
         if valid_set != 0:
-            yamlFile["val"] = os.path.join(output_dir, "valid")
+            yamlFile["val"] = os.path.join(output_dir, "val")
         if test_set != 0:
             yamlFile["test"] = os.path.join(output_dir, "test")
 


### PR DESCRIPTION
Hi, I used this library and with my dataset of about 36000 images takes more than 30 minutes to execute, so I checked the code a bit and tried to optimise the main reading annotation files. 
Now my whole dataset is read in a few seconds.

Other than that, I also changed the print functions with the proper logging function and added some logging of the execution time to better understand the behaviour.

Last but not least I also added the "val" folder to the possible folders that the module can search inside a dataset folder and set it as the default name for the "valid" folder, beacuase in Yolo documentation it is alway referred to as "val" and not "valid".

I hope this can helps someone else other than me.
Let me know what do you think and if anything needs to be changed.

Thanks!